### PR TITLE
Close #5

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -22,7 +22,7 @@ jobs:
       
     # Includes the AsciiDoctor GitHub Pages Action to convert adoc files to html and publish to gh-pages branch
     - name: asciidoctor-ghpages
-      uses: manoelcampos/asciidoctor-ghpages-action@v1.3.0
+      uses: manoelcampos/asciidoctor-ghpages-action@v2.0.0
       with:
         asciidoctor_params: --attribute=nofooter
         pdf_build: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+try.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM asciidoctor/docker-asciidoctor:latest
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -35,104 +35,13 @@ inputs:
     required: false
                   
 runs: 
-  using: "composite"
-
-  # Steps represent a sequence of tasks that will be executed as part of the job
-  steps:
-  - name: Configure git
-    run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-    shell: bash
-
-  - name: Asciidoctor Setup
-    run: |
-      sudo apt-get install gem -y
-      sudo gem install asciidoctor
-    shell: bash
-
-  # Avoids keeping the commit history for the gh-pages branch, 
-  # so that such a branch keeps only the last commit. 
-  # But this slows down the GitHub Pages website build process.
-  - name: Checking out the gh-pages branch without keeping its history
-    run: |
-      git branch -D gh-pages 1>/dev/null 2>/dev/null || true
-      git log | head -n 1 | cut -d' ' -f2 > /tmp/commit-hash.txt
-      git checkout --orphan gh-pages master 1>/dev/null
-    shell: bash
-
-  #- name: Checking out the gh-pages branch, keeping its history
-  #  run: git checkout master -B gh-pages 1>/dev/null
-  #  shell: bash  
-
-  - name: Converting AsciiDoc files to HTML
-    env: 
-      INPUT_ASCIIDOCTOR_PARAMS: ${{ inputs.asciidoctor_params }}
-      INPUT_ADOC_FILE_EXT: ${{ inputs.adoc_file_ext }}
-      # If slides are being generated, the user can skip the execution of the asciidoctor command
-      SLIDES_SKIP_ASCIIDOCTOR_BUILD: ${{ inputs.slides_skip_asciidoctor_build }}
-    run: |
-      if [[ $SLIDES_SKIP_ASCIIDOCTOR_BUILD == false ]]; then 
-        if [[ $INPUT_ADOC_FILE_EXT != .* ]]; then 
-            INPUT_ADOC_FILE_EXT=".$INPUT_ADOC_FILE_EXT"; 
-        fi
-        find . -name "*$INPUT_ADOC_FILE_EXT" | xargs asciidoctor -b html $INPUT_ASCIIDOCTOR_PARAMS
-        for FILE in `find . -name "README.html"`; do 
-            mv "$FILE" "`dirname $FILE`/index.html"; 
-        done
-        for FILE in `find . -name "*.html"`; do 
-          git add -f "$FILE"; 
-        done
-        find . -name "*$INPUT_ADOC_FILE_EXT" | xargs git rm -f --cached
-      fi
-    shell: bash
-
-  - name: Build an ebook.pdf from the AsciiDoc files
-    env: 
-      INPUT_PDF_BUILD: ${{ inputs.pdf_build }}
-      INPUT_ADOC_FILE_EXT: ${{ inputs.adoc_file_ext }}
-      EBOOK_MAIN_ADOC_FILE: ${{ inputs.ebook_main_adoc_file }}
-    run: |
-      if [[ $INPUT_ADOC_FILE_EXT != .* ]]; then 
-        INPUT_ADOC_FILE_EXT=".$INPUT_ADOC_FILE_EXT"; 
-      fi
-      if [[ $INPUT_PDF_BUILD == true ]]; then 
-        PDF_FILE="ebook.pdf"
-        EBOOK_MAIN_ADOC_FILE="$EBOOK_MAIN_ADOC_FILE$INPUT_ADOC_FILE_EXT"
-        sudo gem install asciidoctor-pdf
-        MSG="Building $PDF_FILE ebook from $EBOOK_MAIN_ADOC_FILE"
-        echo $MSG
-        asciidoctor-pdf "$EBOOK_MAIN_ADOC_FILE" -o "$PDF_FILE"
-        git add -f "$PDF_FILE"; 
-      fi
-    shell: bash
-
-  - name: Build AsciiDoc Reveal.js slides
-    env: 
-      INPUT_ADOC_FILE_EXT: ${{ inputs.adoc_file_ext }}
-      SLIDES_BUILD: ${{ inputs.slides_build }}
-      SLIDES_MAIN_ADOC_FILE: ${{ inputs.slides_main_adoc_file }}
-    run: |
-      if [[ $INPUT_ADOC_FILE_EXT != .* ]]; then 
-        INPUT_ADOC_FILE_EXT=".$INPUT_ADOC_FILE_EXT"; 
-      fi
-      if [[ $SLIDES_BUILD == true ]]; then 
-        SLIDES_FILE="slides.html"
-        SLIDES_MAIN_ADOC_FILE="$SLIDES_MAIN_ADOC_FILE$INPUT_ADOC_FILE_EXT"
-        sudo gem install asciidoctor-revealjs
-        MSG="Building $SLIDES_FILE with AsciiDoc Reveal.js from $SLIDES_MAIN_ADOC_FILE"
-        echo $MSG
-        asciidoctor-revealjs "$SLIDES_MAIN_ADOC_FILE" -o "$SLIDES_FILE"
-        git add -f "$SLIDES_FILE"; 
-      fi
-    shell: bash    
-
-  - name: Commiting changes to gh-pages branch
-    env: 
-      INPUT_ADOC_FILE_EXT: ${{ inputs.adoc_file_ext }}
-    run: |
-      MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages from commit `cat /tmp/commit-hash.txt`"
-      git rm -rf .github/
-      git commit -m "$MSG" 1>/dev/null 
-      git push -f --quiet --set-upstream origin gh-pages 1>/dev/null 
-    shell: bash
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.asciidoctor_params }}
+    - ${{ inputs.adoc_file_ext }}
+    - ${{ inputs.slides_build }}
+    - ${{ inputs.slides_main_adoc_file }}
+    - ${{ inputs.slides_skip_asciidoctor_build }}
+    - ${{ inputs.pdf_build }}
+    - ${{ inputs.ebook_main_adoc_file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Exit if a command fails
+set -e
+
+sh -c "echo 'Input Parameters:' $*"
+
+OWNER="$(echo $GITHUB_REPOSITORY| cut -d'/' -f 1)"
+
+if [[ "$INPUT_ADOC_FILE_EXT" != .* ]]; then 
+    INPUT_ADOC_FILE_EXT=".$INPUT_ADOC_FILE_EXT"; 
+fi
+
+# Steps represent a sequence of tasks that will be executed as part of the job
+echo "Configure git"
+apk add git -q > /dev/null
+apk add openssh-client -q > /dev/null
+
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+
+
+# Avoids keeping the commit history for the gh-pages branch, 
+# so that such a branch keeps only the last commit. 
+# But this slows down the GitHub Pages website build process.
+echo "Checking out the gh-pages branch without keeping its history"
+git branch -D gh-pages 1>/dev/null 2>/dev/null || true
+git log | head -n 1 | cut -d' ' -f2 > /tmp/commit-hash.txt
+git checkout -q --orphan gh-pages master 1>/dev/null
+
+#echo "Checking out the gh-pages branch, keeping its history"
+#git checkout master -B gh-pages 1>/dev/null
+
+
+if [[ $INPUT_SLIDES_SKIP_ASCIIDOCTOR_BUILD == false ]]; then 
+    echo "Converting AsciiDoc files to HTML"
+    find . -name "*$INPUT_ADOC_FILE_EXT" | xargs asciidoctor -b html $INPUT_ASCIIDOCTOR_PARAMS
+
+    for FILE in `find . -name "README.html"`; do 
+        mv "$FILE" "`dirname $FILE`/index.html"; 
+    done
+
+    for FILE in `find . -name "*.html"`; do 
+        git add -f "$FILE"; 
+    done
+
+    find . -name "*$INPUT_ADOC_FILE_EXT" | xargs git rm -f --cached
+fi
+
+if [[ $INPUT_PDF_BUILD == true ]]; then 
+    PDF_FILE="ebook.pdf"
+    INPUT_EBOOK_MAIN_ADOC_FILE="$INPUT_EBOOK_MAIN_ADOC_FILE$INPUT_ADOC_FILE_EXT"
+    MSG="Building $PDF_FILE ebook from $INPUT_EBOOK_MAIN_ADOC_FILE"
+    echo $MSG
+    asciidoctor-pdf "$INPUT_EBOOK_MAIN_ADOC_FILE" -o "$PDF_FILE"
+    git add -f "$PDF_FILE"; 
+fi
+
+if [[ $INPUT_SLIDES_BUILD == true ]]; then 
+    echo "Build AsciiDoc Reveal.js slides"
+    SLIDES_FILE="slides.html"
+    INPUT_SLIDES_MAIN_ADOC_FILE="$INPUT_SLIDES_MAIN_ADOC_FILE$INPUT_ADOC_FILE_EXT"
+    MSG="Building $SLIDES_FILE with AsciiDoc Reveal.js from $INPUT_SLIDES_MAIN_ADOC_FILE"
+    echo $MSG
+    asciidoctor-revealjs "$INPUT_SLIDES_MAIN_ADOC_FILE" -o "$SLIDES_FILE"
+    git add -f "$SLIDES_FILE"; 
+fi
+
+MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages from commit `cat /tmp/commit-hash.txt`"
+git rm -rf .github/
+echo "Commiting changes to gh-pages branch"
+git commit -m "$MSG" 1>/dev/null
+
+echo "
+StrictHostKeyChecking no
+UserKnownHostsFile=/dev/null
+" > /etc/ssh/ssh_config
+
+# If the action is being run into the GitHub Servers,
+# the checkout action (which is being used)
+# automatically authenticates the container using ssh.
+# If the action is running locally, for instance using https://github.com/nektos/act,
+# we need to push via https with a Personal Access Token 
+# which should be provided by an env variable.
+# We ca run the action locally using act with:
+#    act -s GITHUB_TOKEN=my_github_personal_access_token
+if ! ssh -T git@github.com > /dev/null 2>/dev/null; then
+    URL="https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+    git remote remove origin
+    git remote add origin $URL
+fi
+
+echo "Pushing changes back to the remote repository"
+git push -f --set-upstream origin gh-pages 


### PR DESCRIPTION
You can use the [nektos/act](https://github.com/nektos/act) tool run the action using Docker locally.
For that, you need to create a GitHub Personal Access Token and run act with the following commando:

```bash
act -s GITHUB_TOKEN=my_github_personal_access_token
```

The changes performed by this PR are as follows:

- Use asciidoctor official alpine image
- Change 'apt-get install' by 'apk add'
- Install git
- Remove sudo from commands
- Remove installation of asciidoctor-pdf e asciidoctor-revealjs
  because they are already installed in the container.
- Add INPUT_ prefix for input params into the entrypoint.sh,
  because that is the way they are passed to the script
- Remove the git clone since the checkout action is being used
- Install openssh-client
- Configure ssh
- Configure git remote to authentica via https
  when the action is run locally, using nektos/act for instance.
  Use just the access token to authenticate.
- Supress ssh warning 'Permanently added to the list of known hosts'
- Provide documentation to run the action locally
  Using the nektos/act, we can run the
  action locally using docker.
  The entrypoint.sh was documented to show how.