### PR TITLE
fix: add changes on top of each other

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,14 +32,10 @@ echo "Default branch: $default_branch"
 # Avoids keeping the commit history for the gh-pages branch, 
 # so that such a branch keeps only the last commit. 
 # But this slows down the GitHub Pages website build process.
-# echo "Checking out the gh-pages branch without keeping its history"
-# git branch -D gh-pages 1>/dev/null 2>/dev/null || true
-# git log | head -n 1 | cut -d' ' -f2 > /tmp/commit-hash.txt
-# git fetch --all
-# git checkout -q --orphan gh-pages $default_branch 1>/dev/null
 
 echo "Checking out the gh-pages branch, keeping its history"
-git checkout $default_branch -B gh-pages 1>/dev/null
+git fetch --all
+git checkout $default_branch -B gh-pages
 
 
 if [[ $INPUT_SLIDES_SKIP_ASCIIDOCTOR_BUILD == false ]]; then 
@@ -76,7 +72,7 @@ if [[ $INPUT_SLIDES_BUILD == true ]]; then
     git add -f "$SLIDES_FILE"; 
 fi
 
-MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages from commit `cat /tmp/commit-hash.txt`"
+MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages"
 git rm -rf .github/
 echo "Commiting changes to gh-pages branch"
 git commit -m "$MSG" 1>/dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,24 +19,12 @@ apk add openssh-client -q > /dev/null
 git config --local user.email "action@github.com"
 git config --local user.name "GitHub Action"
 
-
-# Taking care of the fact that GitHub repos can have a default
-# branch which can either be named master or main
-
-default_branch="master"
-if ! git show-branch --list $default_branch 2>/dev/null; then
-   default_branch="main"
-fi
-echo "Default branch: $default_branch"
-
-# Avoids keeping the commit history for the gh-pages branch, 
-# so that such a branch keeps only the last commit. 
-# But this slows down the GitHub Pages website build process.
+# Gets latest commit hash for pushed branch
+COMMIT_HASH=$(git rev-parse HEAD)
 
 echo "Checking out the gh-pages branch, keeping its history"
 git fetch --all
-git checkout $default_branch -B gh-pages
-
+git checkout $COMMIT_HASH -B gh-pages
 
 if [[ $INPUT_SLIDES_SKIP_ASCIIDOCTOR_BUILD == false ]]; then 
     echo "Converting AsciiDoc files to HTML"
@@ -72,9 +60,9 @@ if [[ $INPUT_SLIDES_BUILD == true ]]; then
     git add -f "$SLIDES_FILE"; 
 fi
 
-MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages"
+MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages from $COMMIT_HASH"
 git rm -rf .github/
-echo "Commiting changes to gh-pages branch"
+echo "Committing changes to gh-pages branch"
 git commit -m "$MSG" 1>/dev/null
 
 echo "
@@ -97,4 +85,4 @@ if ! ssh -T git@github.com > /dev/null 2>/dev/null; then
 fi
 
 echo "Pushing changes back to the remote repository"
-git push -f --set-upstream origin gh-pages 
+git push -f --set-upstream origin gh-pages

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ git config --local user.name "GitHub Action"
 # Gets latest commit hash for pushed branch
 COMMIT_HASH=$(git rev-parse HEAD)
 
-echo "Checking out the gh-pages branch, keeping its history"
+echo "Checking out the gh-pages branch (keeping its history) from commit $COMMIT_HASH"
 git fetch --all
 git checkout $COMMIT_HASH -B gh-pages
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ echo "Default branch: $default_branch"
 # git fetch --all
 # git checkout -q --orphan gh-pages $default_branch 1>/dev/null
 
-#echo "Checking out the gh-pages branch, keeping its history"
+echo "Checking out the gh-pages branch, keeping its history"
 git checkout $default_branch -B gh-pages 1>/dev/null
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,14 +32,14 @@ echo "Default branch: $default_branch"
 # Avoids keeping the commit history for the gh-pages branch, 
 # so that such a branch keeps only the last commit. 
 # But this slows down the GitHub Pages website build process.
-echo "Checking out the gh-pages branch without keeping its history"
-git branch -D gh-pages 1>/dev/null 2>/dev/null || true
-git log | head -n 1 | cut -d' ' -f2 > /tmp/commit-hash.txt
-git fetch --all
-git checkout -q --orphan gh-pages $default_branch 1>/dev/null
+# echo "Checking out the gh-pages branch without keeping its history"
+# git branch -D gh-pages 1>/dev/null 2>/dev/null || true
+# git log | head -n 1 | cut -d' ' -f2 > /tmp/commit-hash.txt
+# git fetch --all
+# git checkout -q --orphan gh-pages $default_branch 1>/dev/null
 
 #echo "Checking out the gh-pages branch, keeping its history"
-#git checkout master -B gh-pages 1>/dev/null
+git checkout $default_branch -B gh-pages 1>/dev/null
 
 
 if [[ $INPUT_SLIDES_SKIP_ASCIIDOCTOR_BUILD == false ]]; then 


### PR DESCRIPTION
Current action doesn't work because of broken git syntax.

Additionally I feel like adding fresh changes by default has so many disadvantages (bigger size, slow builds, lack of visibility of what changed) that it will make sense to simply enable second flow.

Error:
fatal: 'main' is not a commit and a branch 'gh-pages' cannot be created from it
