### PR TITLE
add $INPUT_ASCIIDOCTOR_PARAMS to pdf outputs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ if [[ $INPUT_PDF_BUILD == true ]]; then
     INPUT_EBOOK_MAIN_ADOC_FILE="$INPUT_EBOOK_MAIN_ADOC_FILE$INPUT_ADOC_FILE_EXT"
     MSG="Building $PDF_FILE ebook from $INPUT_EBOOK_MAIN_ADOC_FILE"
     echo $MSG
-    asciidoctor-pdf "$INPUT_EBOOK_MAIN_ADOC_FILE" -o "$PDF_FILE"
+    asciidoctor-pdf "$INPUT_EBOOK_MAIN_ADOC_FILE" -o "$PDF_FILE" $INPUT_ASCIIDOCTOR_PARAMS
     git add -f "$PDF_FILE"; 
 fi
 


### PR DESCRIPTION
I was using diagrams, which worked for html but not pdf

because `-r asciidoctor-diagram` was not being passed to `asciidoctor-pdf`