### PR TITLE
Add git LFS support.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: asciidoctor-ghpages
-author: Manoel Campos da Silva Filho
+name: asciidoctor-ghpages-lfs
+author: Manoel Campos da Silva Filho (Original Author)
 branding:
   icon: book-open
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,11 @@ if [[ "$INPUT_ADOC_FILE_EXT" != .* ]]; then
     INPUT_ADOC_FILE_EXT=".$INPUT_ADOC_FILE_EXT";
 fi
 
+# Install git-lfs since it is not in Alpine base image.
+echo "Install git-lfs"
+apk update
+apk add --update git-lfs
+
 echo "Configure git"
 apk add openssh-client -q > /dev/null
 


### PR DESCRIPTION
Adds the support for git repositories with LFS enabled. Since the Alpine base image doesn't include the git-lfs package, we do the installation of git-lfs in the entrypoint.sh.