### PR TITLE
feat: #47 add optional ability to pass --signoff through to the git commit command line

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -31,3 +31,4 @@ jobs:
         # slides_build: true
         # pre_build:
         # post_build:
+        # git_commit_signoff: false

--- a/README.adoc
+++ b/README.adoc
@@ -114,3 +114,8 @@ endif::[]
 === How can I configure a custom domain?
 
 GitHub Pages need a `CNAME` file on the `gh-pages` branch. But on every action run, the `gh-pages` branch is wiped out. To make a custom domain work, just add the `CNAME` file in the root directory of your `main` or `master` branch instead and it will be copied over to the `gh-pages` branch automatically. If you have a `source_dir` configured, the `CNAME` file must be inside your configured `source_dir`.
+
+=== My repository enforces https://wiki.linuxfoundation.org/dco[DCO] on all commits, how can I configure this action to work with that?
+
+Set the `git_commit_signoff` input parameter to `true`.  This will cause this action to supply the `--signoff` flag when performing the git commit.  The signoff will attributed to
+`GitHub Action <action@github.com>`.

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'Any arbitrary shell command to be executed after the asciidoc build is complete and before committing changes on gh-pages branch. Optional.'
     default: 'echo "No post build command provided."'
     required: false
+  git_commit_signoff:
+    description: 'If set true, the --signoff flag will be passed to git commit command, Optional.'
+    default: 'false'
+    required: false
                   
 runs: 
   using: docker
@@ -60,3 +64,4 @@ runs:
     - ${{ inputs.ebook_main_adoc_file }}
     - ${{ inputs.pre_build }}
     - ${{ inputs.post_build }}
+    - ${{ inputs.git_commit_signoff}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,6 +83,12 @@ if [[ $INPUT_SLIDES_BUILD == true ]]; then
     git add -f "$SLIDES_FILE";
 fi
 
+
+GIT_COMMIT_SIGNOFF="--no-signoff"
+if [[ "$INPUT_GIT_COMMIT_SIGNOFF" == true  ]]; then
+  GIT_COMMIT_SIGNOFF="--signoff"
+fi
+
 # Changes in gh-pages branch will be shown as the "GitHub Action" user.
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
@@ -90,7 +96,7 @@ git config --global user.name "GitHub Action"
 MSG="Build $INPUT_ADOC_FILE_EXT Files for GitHub Pages from $GITHUB_SHA"
 git rm -rf .github/ || true
 echo "Committing changes to gh-pages branch"
-git commit -m "$MSG" 1>/dev/null
+git commit $GIT_COMMIT_SIGNOFF -m "$MSG" 1>/dev/null
 
 # If the action is being run into the GitHub Servers,
 # the checkout action (which is being used)


### PR DESCRIPTION
Proposed fix for #47.

why: if repos have enabled DCO, the commit will be rejected if the commit message doesn't have the 'Signed-off-by: text'